### PR TITLE
rename defwidget to defroute

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,14 @@
  ChangeLog
 ===========
 
+
+Changes
+-------
+
+* Renamed ``defwidget`` to ``defroutes``, so that it is more explicit
+  and it doesn't clash with ``weblocks/widget:defwidget``.
+
+
 0.5.0 (2019-01-22)
 ==================
 
@@ -10,7 +18,7 @@ Changes
 
 * Function ``weblocks/response:abort-processing`` was replaced with
   ``weblocks/response:immediate-response`` to work with ``Weblocks >= 0.35.0``.
-  
+
 
 0.4.1 (2018-11-25)
 ==================

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -13,7 +13,7 @@
                 #:immediate-response)
   (:export
    #:make-navigation-widget
-   #:defwidget))
+   #:defroutes))
 (in-package weblocks-navigation-widget)
 
 
@@ -65,7 +65,7 @@
                   :rules ,(make-lambda-rules rules)))
 
 
-(defmacro defwidget (class-name &rest rules)
+(defmacro defroutes (class-name &rest rules)
   "Defines a new class with name <class-name>, inherited from `navigation-widget'.
 
    And a function `make-<class-name>' to make instances of this class."


### PR DESCRIPTION
I renamed defwidget to defroute, however there are other names with "navigation", is it consistent ?

- navigation-widget and make-navigation-widget -> [make-]route-widget ? Or `defroute` should actually be `defnavigation` ?


closes #2 